### PR TITLE
make unitfile independent of docker.service

### DIFF
--- a/systemd/docker-lvm-plugin.service
+++ b/systemd/docker-lvm-plugin.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Docker Volume Driver for lvm volumes
 Documentation=man:docker-lvm-plugin(8)
-Before=docker.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
This allows both docker and docker-latest to use lvm-plugin without any
changes in lvm-plugin's unitfile.

Instead docker and docker-latest's unitfiles will have a dependency on
docker-lvm-plugin like so:

After=docker-lvm-plugin.socket

Signed-off-by: Lokesh Mandvekar lsm5@fedoraproject.org
