### PR TITLE
Add optional argument to select volume group

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Following options can be passed using `-o` or `--opt`
 --opt thinpool
 --opt snapshot
 --opt keyfile
+--opt vg
 ``` 
 Please see examples below on how to use these options.
 
@@ -77,7 +78,13 @@ Please see examples below on how to use these options.
 ```bash
 $ docker volume create -d lvm --opt size=0.2G --name foobar
 ```
-This will create a lvm volume named `foobar` of size 208 MB (0.2 GB).
+This will create a lvm volume named `foobar` of size 208 MB (0.2 GB) in the
+default volume group.
+```bash
+$ docker volume create -d lvm --opt size=0.2G --opt vg=vg0 --name foobar
+```
+This will create a lvm volume named `foobar` of size 208 MB (0.2 GB) in the
+default volume vg0.
 ```bash
 docker volume create -d lvm --opt size=0.2G --opt thinpool=mythinpool --name thin_vol
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # docker lvm plugin
 Docker Volume Driver for lvm volumes
 
-This plugin can be used to create lvm volumes of specified size, which can 
+This plugin can be used to create lvm volumes of specified size, which can
 then be bind mounted into the container using `docker run` command.
 
 ## Setup
@@ -29,19 +29,19 @@ sudo systemctl start docker-lvm-plugin
 NOTE: docker-lvm-plugin daemon is on-demand socket activated. Running `docker volume ls` command
 will automatically start the daemon.
 
-3) Since logical volumes (lv's) are based on a volume group, it is the 
+3) Since logical volumes (lv's) are based on a volume group, it is the
    responsibility of the user (administrator) to provide a volume group name.
-   You can choose an existing volume group name by listing volume groups on 
-   your system using `vgs` command OR create a new volume group using 
+   You can choose an existing volume group name by listing volume groups on
+   your system using `vgs` command OR create a new volume group using
    `vgcreate` command.
-   e.g. 
+   e.g.
 ```bash
-vgcreate vg1 /dev/hda 
+vgcreate vg0 /dev/hda
 ```
-   where /dev/hda is your partition or whole disk on which physical volumes 
+   where /dev/hda is your partition or whole disk on which physical volumes
    were created.
 
-4) Add this volume group name in the config file 
+4) Add this volume group name in the config file
 ```bash
 /etc/docker/docker-lvm-plugin
 ```
@@ -50,9 +50,9 @@ vgcreate vg1 /dev/hda
 ```bash
 lvcreate -L 10G -T vg1/mythinpool
 ```
-This will create a thinpool named `mythinpool` of size 10G under volume group `vg1`.
+This will create a thinpool named `mythinpool` of size 10G under volume group `vg0`.
 NOTE: thinpools are special kind of logical volumes carved out of the volume group.
-Hence in the above example, to create the thinpool `mythinpool` you must have atleast 10G of freespace in volume group `vg1`. 
+Hence in the above example, to create the thinpool `mythinpool` you must have atleast 10G of freespace in volume group `vg0`.
 
 ## Volume Creation
 `docker volume create` command supports the creation of regular lvm volumes, thin volumes, snapshots of regular and thin volumes.
@@ -62,7 +62,7 @@ Usage: docker volume create [OPTIONS]
 -d, --driver    string    Specify volume driver name (default "local")
 --label         list      Set metadata for a volume (default [])
 --name          string    Specify volume name
--o, --opt       map       Set driver specific options (default map[]) 
+-o, --opt       map       Set driver specific options (default map[])
 ```
 Following options can be passed using `-o` or `--opt`
 ```bash
@@ -71,7 +71,7 @@ Following options can be passed using `-o` or `--opt`
 --opt snapshot
 --opt keyfile
 --opt vg
-``` 
+```
 Please see examples below on how to use these options.
 
 ## Examples
@@ -79,12 +79,12 @@ Please see examples below on how to use these options.
 $ docker volume create -d lvm --opt size=0.2G --name foobar
 ```
 This will create a lvm volume named `foobar` of size 208 MB (0.2 GB) in the
-default volume group.
+volume group vg0.
 ```bash
-$ docker volume create -d lvm --opt size=0.2G --opt vg=vg0 --name foobar
+$ docker volume create -d lvm --opt size=0.2G --opt vg=vg1 --name foobar
 ```
 This will create a lvm volume named `foobar` of size 208 MB (0.2 GB) in the
-default volume vg0.
+volume group vg1.
 ```bash
 docker volume create -d lvm --opt size=0.2G --opt thinpool=mythinpool --name thin_vol
 ```

--- a/driver.go
+++ b/driver.go
@@ -223,9 +223,16 @@ func (l *lvmDriver) Remove(req *volume.RemoveRequest) error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
+	vgName, err := getVolumegroupName(l.vgConfig)
+	if err != nil {
+		return err
+	}
 	vol, exists := l.volumes[req.Name]
 	if !exists {
 		return nil
+	}
+	if vol.VgName == "" {
+		vol.VgName = vgName
 	}
 
 	isOrigin := func() bool {
@@ -269,9 +276,16 @@ func (l *lvmDriver) Mount(req *volume.MountRequest) (*volume.MountResponse, erro
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
+	vgName, err := getVolumegroupName(l.vgConfig)
+	if err != nil {
+		return &volume.MountResponse{}, err
+	}
 	vol, exists := l.volumes[req.Name]
 	if !exists {
 		return &volume.MountResponse{}, fmt.Errorf("Unknown volume %s", req.Name)
+	}
+	if vol.VgName == "" {
+		vol.VgName = vgName
 	}
 
 	isSnap, keyFile := func() (bool, string) {

--- a/driver.go
+++ b/driver.go
@@ -302,8 +302,7 @@ func (l *lvmDriver) Mount(req *volume.MountRequest) (*volume.MountResponse, erro
 		device := logicalDevice(vol.VgName, req.Name)
 
 		if keyFile != "" {
-			err := keyFileExists(keyFile)
-			if err != nil {
+			if err := keyFileExists(keyFile); err != nil {
 				l.logger.Err(fmt.Sprintf("Mount: %s", err))
 				return &volume.MountResponse{}, err
 			}

--- a/driver.go
+++ b/driver.go
@@ -229,7 +229,7 @@ func (l *lvmDriver) Remove(req *volume.RemoveRequest) error {
 	}
 	vol, exists := l.volumes[req.Name]
 	if !exists {
-		return nil
+		return fmt.Errorf("Error removing volume, missing description in lvmConfigVolumes.json")
 	}
 	if vol.VgName == "" {
 		vol.VgName = vgName

--- a/man/docker-lvm-plugin.8.md
+++ b/man/docker-lvm-plugin.8.md
@@ -1,45 +1,48 @@
-% DOCKER-LVM-PLUGIN(8) 
-% Shishir Mahajan 
+% DOCKER-LVM-PLUGIN(8)
+% Shishir Mahajan
 % FEBRUARY 2016
 # NAME
 docker-lvm-plugin - Docker Volume Driver for lvm volumes
 
 # SYNOPSIS
-**docker-lvm-plugin**
-[**-debug**]
-[**-version**]
+**docker volume create -d lvm**
+[**--opt size**]
+[**--opt thinpool**]
+[**--opt snapshot**]
+[**--opt keyfile**]
+[**--opt vg**]
 
 # DESCRIPTION
 This plugin can be used to create lvm volumes of specified size,
-which can then be bind mounted into the container using `docker run` 
-command. 
+which can then be bind mounted into the container using `docker run`
+command.
 
 # USAGE
-Start the docker daemon before starting the docker-lvm-plugin daemon. 
+Start the docker daemon before starting the docker-lvm-plugin daemon.
 You can start docker daemon using command:
 ```bash
-systemctl start docker 
+systemctl start docker
 ```
 Once docker daemon is up and running, you can start docker-lvm-plugin daemon
 using command:
 ```bash
 systemctl start docker-lvm-plugin
-``` 
+```
 docker-lvm-plugin daemon is on-demand socket activated. Running `docker volume ls` command
 will automatically start the daemon.
 
-Since logical volumes (lv's) are based on a volume group, it is the 
-responsibility of the user (administrator) to provide a volume group name. 
-You can choose an existing volume group name by listing volume groups on 
-your system using `vgs` command OR create a new volume group using `vgcreate` 
+Since logical volumes (lv's) are based on a volume group, it is the
+responsibility of the user (administrator) to provide a volume group name.
+You can choose an existing volume group name by listing volume groups on
+your system using `vgs` command OR create a new volume group using `vgcreate`
 command. e.g.
 ```bash
-vgcreate vg1 /dev/hda 
+vgcreate vg0 /dev/hda
 ```
-where /dev/hda is your partition or whole disk on which physical volumes 
+where /dev/hda is your partition or whole disk on which physical volumes
 were created.
 
-Add this volume group name in the config file. 
+Add this volume group name in the config file.
 ```bash
 /etc/docker/docker-lvm-plugin
 ```
@@ -47,22 +50,34 @@ The docker-lvm-plugin also supports the creation of thinly-provisioned volumes. 
 ```bash
 lvcreate -L 10G -T vg1/mythinpool
 ```
-This will create a thinpool named `mythinpool` of size 10G under volume group `vg1`.
+This will create a thinpool named `mythinpool` of size 10G under volume group `vg0`.
 NOTE: thinpools are special kind of logical volumes carved out of the volume group.
-Hence in the above example, to create the thinpool `mythinpool` you must have atleast 10G of freespace in volume group `vg1`.
+Hence in the above example, to create the thinpool `mythinpool` you must have atleast 10G of freespace in volume group `vg0`.
 
 # OPTIONS
-**-debug**=*true*|*false*
-  Enable debug logging. Default is false.
-**-version**=*true*|*false*
-  Print version information and quit. Default is false.
+**--opt size**=*size*
+  Set the size of the volume.
+**--opt thinpool**=*thinpool name*
+  Create a thinly-provisioned lvm volume.
+**--opt snapshot**=*snapshot name*
+  Create a snapshot volume of an existing lvm volume.
+**--opt keyfile**=*keyfile name*
+  Create a LUKS encrypted lvm volume.
+**--opt vg**=*volume group name*
+  Create the volume in the specified volume group.
 
 # EXAMPLES
 **Volume Creation**
 ```bash
 docker volume create -d lvm --opt size=0.2G --name foobar
 ```
-This will create a lvm volume named foobar of size 208 MB (0.2 GB).
+This will create a lvm volume named foobar of size 208 MB (0.2 GB) in the
+volume group vg0.
+```bash
+$ docker volume create -d lvm --opt size=0.2G --opt vg=vg1 --name foobar
+```
+This will create a lvm volume named `foobar` of size 208 MB (0.2 GB) in the
+volume group vg1.
 ```bash
 docker volume create -d lvm --opt size=0.2G --opt thinpool=mythinpool --name thin_vol
 ```


### PR DESCRIPTION
This PR adds a new option `vg` that allows to specify a volume group different from the default defined in `/etc/docker/docker-lvm-plugin` at a per-volume basis. The volume group is also stored in `/var/lib/docker-lvm-plugin/lvmVolumesConfig.json` to have it available for volume mount and remove operations.

Usage
```bash
docker volume create -d lvm --opt size=100G --opt vg=vg1 --name=data
```

This PR should also resolve #7 since it provides a convenient way to specify a volume group on docker command line, in docker-compose and other docker config files (swarm, etc).

Tested and works with Docker 1.13.1 on CentOS 7.4.
```
# docker info
Containers: 0
 Running: 0
 Paused: 0
 Stopped: 0
Images: 0
Server Version: 1.13.1
Storage Driver: devicemapper
 Pool Name: vg0-docker--pool
 Pool Blocksize: 524.3 kB
 Base Device Size: 4.295 GB
 Backing Filesystem: xfs
 Data file:
 Metadata file:
 Data Space Used: 15.73 MB
 Data Space Total: 21.47 GB
 Data Space Available: 21.46 GB
 Metadata Space Used: 106.5 kB
 Metadata Space Total: 960.5 MB
 Metadata Space Available: 960.4 MB
 Thin Pool Minimum Free Space: 2.147 GB
 Udev Sync Supported: true
 Deferred Removal Enabled: true
 Deferred Deletion Enabled: true
 Deferred Deleted Device Count: 0
 Library Version: 1.02.146-RHEL7 (2018-01-22)
Logging Driver: gelf
Cgroup Driver: systemd
Plugins:
 Volume: local lvm
 Network: bridge host macvlan null overlay
Swarm: inactive
Runtimes: docker-runc runc
Default Runtime: docker-runc
Init Binary: docker-init
containerd version:  (expected: aa8187dbd3b7ad67d8e5e3a15115d3eef43a7ed1)
runc version: N/A (expected: 9df8b306d01f59d3a8029be411de015b7304dd8f)
init version: N/A (expected: 949e6facb77383876aeff8a6944dde66b3089574)
Security Options:
 seccomp
  Profile: default
Kernel Version: 4.16.8-1.el7.elrepo.x86_64
Operating System: CentOS Linux 7 (Core)
OSType: linux
Architecture: x86_64
Number of Docker Hooks: 3
CPUs: 48
Total Memory: 377.5 GiB
Name: XXX
ID: SC35:4TGP:5KDA:BJXK:LTOA:I7O2:63TC:QIIG:3TN4:LGAZ:7SBH:PMJP
Docker Root Dir: /var/lib/docker
Debug Mode (client): false
Debug Mode (server): false
Registry: https://index.docker.io/v1/
WARNING: bridge-nf-call-ip6tables is disabled
Labels:
Experimental: false
Insecure Registries:
 127.0.0.0/8
Live Restore Enabled: true
Registries: docker.io (secure)
```