### PR TITLE
Make logrus import lowercase

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/docker/go-plugins-helpers/volume"
 )
 


### PR DESCRIPTION
As it causes issues the other way around [at least] on macOS. Also, this the "official way" now as per https://github.com/sirupsen/logrus#logrus-