### PR TITLE
Cross-compile for linux.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ MANINSTALLDIR?= ${DESTDIR}/usr/share/man
 BINDIR ?=$(DESTDIR)/usr/libexec/docker
 
 export GO15VENDOREXPERIMENT=1
+export GOOS=linux
 
 all: man lvm-plugin-build
 


### PR DESCRIPTION
This change `export GOOS=linux` will make sure, that the target for compilation is `Linux` even if someone is developing on a mac. This will allow developers to develop both on Mac and Linux.